### PR TITLE
Add `--sync` and `--combine` flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 target/
 
-out/
-
 Cargo.lock
 
+# Common output directory names
+out/
+output/
+
+# Other
 CLAUDE.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ keywords = ["security", "passwords", "hibp", "downloader"]
 categories = ["command-line-utilities", "web-programming::http-client"]
 
 [dependencies]
+anyhow = "1.0.99"
+async-trait = "0.1.86"
 clap = { version = "4.5.47", features = ["derive"] }
 futures = "0.3.31"
 indicatif = "0.18.0"

--- a/README.md
+++ b/README.md
@@ -7,15 +7,17 @@ A fast, async Rust tool to download password hashes from the [Have
 I Been Pwned](https://haveibeenpwned.com/) Pwned Passwords API.  
 This tool downloads all available password hash ranges (00000-FFFFF)
 with support for resuming interrupted downloads, concurrent requests,
-and multiple compression formats.
+multiple compression formats, and efficient incremental sync.
 
 ## Features
 
-- **Fast concurrent downloads**: Configurable number of concurrent requests
+- **Fast concurrent downloads**: Configurable number of concurrent requests (default: 64)
 - **Resume support**: Automatically resumes interrupted downloads using ETag caching
+- **Sync mode**: Download only changed ranges since a previous download
+- **Combined mode**: Merge all ranges into a single sorted file for database import
 - **Compression support**: Save storage space with Brotli, Gzip, or no compression
 - **Progress tracking**: Visual progress bar with ETA
-- **Retry mechanism**: Configurable retry attempts for failed requests
+- **Retry mechanism**: Configurable retry attempts with exponential backoff
 
 ## Installation
 
@@ -31,27 +33,92 @@ cargo install --path .
 
 ### Basic usage
 
-Download all password hashes to the current directory:
+Download all password hashes to the current directory (creates individual files per range):
 
 ```sh
 pwned-passwords-downloader-rs
 ```
 
-### Common options
+### Common workflows
+
+#### Initial download (individual files)
+
+Download all ranges as separate files with compression:
 
 ```sh
-# Download to a specific directory with Brotli compression
-pwned-passwords-downloader-rs --output-directory pwned-passwords --compression brotli
-
-# Use more concurrent requests for faster downloads
-pwned-passwords-downloader-rs --max-concurrent-requests 100
-
-# Quiet mode (no progress bar)
-pwned-passwords-downloader-rs --quiet
-
-# Disable resume functionality
-pwned-passwords-downloader-rs --resume false
+pwned-passwords-downloader-rs \
+  --output-directory ./db-2025-01 \
+  --compression brotli \
+  --max-concurrent-requests 128
 ```
+
+This creates:
+- 1,048,576 individual hash range files (00000-FFFFF)
+- `.etag_cache.json` for resume/sync support
+- `download_debug.log` for validation
+
+#### Initial download (combined file)
+
+Download all ranges into a single sorted file (ideal for database import):
+
+```sh
+pwned-passwords-downloader-rs \
+  --output-directory ./db-2025-01 \
+  --combine \
+  --max-concurrent-requests 256
+```
+
+This creates:
+- `pwned-passwords-combined.txt` with all hashes in sorted order
+- `.etag_cache.json` for resume/sync support
+- `download_debug.log` for validation
+
+#### Resume interrupted download
+
+If a download is interrupted (Ctrl-C, network failure, etc.), simply run the same command again with `--resume`:
+
+```sh
+pwned-passwords-downloader-rs \
+  --output-directory ./db-2025-01 \
+  --resume \
+  --combine \
+  --max-concurrent-requests 256
+```
+
+The downloader will skip already-downloaded ranges using the ETag cache.
+
+#### Incremental sync (download only changes)
+
+Download only ranges that changed since a previous download:
+
+```sh
+# First download in January
+pwned-passwords-downloader-rs --output-directory ./db-2025-01 --combine
+
+# Later download in February (only changed ranges)
+pwned-passwords-downloader-rs \
+  --output-directory ./db-2025-02 \
+  --sync ./db-2025-01/.etag_cache.json \
+  --combine \
+  --max-concurrent-requests 256
+```
+
+The `--sync` flag uses the previous ETag cache to send `If-None-Match` headers, resulting in HTTP 304 responses for unchanged ranges. This significantly reduces download time and bandwidth.
+
+#### Resume with sync
+
+You can combine `--resume` and `--sync` for maximum efficiency:
+
+```sh
+pwned-passwords-downloader-rs \
+  --output-directory ./db-2025-02 \
+  --resume \
+  --sync ./db-2025-01/.etag_cache.json \
+  --combine \
+  --max-concurrent-requests 256
+```
+
+Priority order: resume cache (current session) > sync cache (previous state)
 
 ### All options
 
@@ -59,12 +126,16 @@ pwned-passwords-downloader-rs --resume false
 Options:
   -c, --compression <COMPRESSION>
           Compression format for storing downloaded hashes [default: none] [possible values: none, brotli, gzip]
+      --combine
+          Combine all hash ranges into a single sorted output file
       --max-concurrent-requests <MAX_CONCURRENT_REQUESTS>
           Maximum number of concurrent requests [default: 64]
       --max-retries <MAX_RETRIES>
           Number of retry attempts for failed requests [default: 5]
       --resume [<RESUME>]
           Resume previous download session [default: true] [possible values: true, false]
+      --sync <SYNC>
+          Path to previous ETag cache for incremental sync
   -o, --output-directory <OUTPUT_DIRECTORY>
           Directory for storing downloaded hashes [default: .]
   -q, --quiet
@@ -75,6 +146,82 @@ Options:
           Print help (see more with '--help')
   -V, --version
           Print version
+```
+
+## File Structure
+
+### Individual file mode (default)
+
+```
+output-directory/
+├── 00000                    # Hash range 00000
+├── 00001                    # Hash range 00001
+├── ...                      # (1,048,576 total files)
+├── FFFFF                    # Hash range FFFFF
+├── .etag_cache.json        # ETag cache for resume/sync
+└── download_debug.log      # Debug log with timestamps
+```
+
+Each range file contains lines in the format:
+```
+<35-char-hash-suffix>:<count>
+```
+
+Example (`00000` file):
+```
+0005AD76BD555C1D6D771DE417A4B87E4B4:10
+000A8DAE4228F821FB418F59826079BF368:4
+000DD7F2A1C68A35673713783CA390C9E93:876
+```
+
+### Combined file mode (`--combine`)
+
+```
+output-directory/
+├── pwned-passwords-combined.txt    # All ranges in single sorted file
+├── .etag_cache.json                # ETag cache for resume/sync
+└── download_debug.log              # Debug log with timestamps
+```
+
+The combined file contains lines in the format:
+```
+<40-char-full-sha1-hash>:<count>
+```
+
+Example (`pwned-passwords-combined.txt`):
+```
+000000005AD76BD555C1D6D771DE417A4B87E4B4:10
+0000000A8DAE4228F821FB418F59826079BF368:4
+0000000DD7F2A1C68A35673713783CA390C9E93:876
+```
+
+All hashes are sorted lexicographically, making the file ready for database import.
+
+### ETag cache format
+
+The `.etag_cache.json` file stores ETags for each hash range:
+
+```json
+{
+  "00000": "\"abc123def456\"",
+  "00001": "\"xyz789uvw012\"",
+  ...
+}
+```
+
+This cache enables:
+- Resume functionality (skip already-downloaded ranges)
+- Sync functionality (detect changed ranges via `If-None-Match` headers)
+- HTTP 304 responses for unchanged data
+
+### Debug log format
+
+The `download_debug.log` file contains timestamped entries for validation:
+
+```
+2025-10-01T12:34:56.789Z Range 00000 written (1048576 bytes)
+2025-10-01T12:34:56.890Z Range 00001 written (1048576 bytes)
+...
 ```
 
 ## License

--- a/scripts/test_etag_sync.sh
+++ b/scripts/test_etag_sync.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+
+# Test script to validate ETag cache synchronization with actual file contents
+
+set -e
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${YELLOW}=== Testing ETag Cache Synchronization ===${NC}"
+
+# Build release binary if needed
+if [ ! -f "./target/release/pwned-passwords-downloader-rs" ]; then
+    echo "Building release binary..."
+    cargo build --release
+fi
+
+TEST_DIR="test_etag_sync_$$"
+mkdir -p "$TEST_DIR"
+
+echo -e "\n${GREEN}Test: Download with interruption, then validate ETag/file consistency${NC}"
+
+# Download for a short time then interrupt
+echo "Starting download (will interrupt after 10 seconds)..."
+(./target/release/pwned-passwords-downloader-rs \
+    --combine \
+    --output-directory "$TEST_DIR" \
+    --max-concurrent-requests 32 \
+    --quiet) &
+PID=$!
+sleep 10
+kill -INT $PID 2>/dev/null || true
+wait $PID 2>/dev/null || true
+
+echo -e "\n${YELLOW}Analyzing results...${NC}"
+
+# Get ranges from ETag cache
+ETAG_RANGES=$(grep -o '"[0-9A-F]\{5\}"' "$TEST_DIR/.etag_cache.json" 2>/dev/null | tr -d '"' | sort || true)
+ETAG_COUNT=$(echo "$ETAG_RANGES" | grep -v '^$' | wc -l | tr -d ' ')
+
+# Get ranges from combined file
+FILE_RANGES=$(grep "^# Range:" "$TEST_DIR/pwned-passwords-combined.txt" 2>/dev/null | awk '{print $3}' | sort || true)
+FILE_COUNT=$(echo "$FILE_RANGES" | grep -v '^$' | wc -l | tr -d ' ')
+
+echo "Ranges in ETag cache: $ETAG_COUNT"
+echo "Ranges in file: $FILE_COUNT"
+
+# Compare the sets
+if [ "$ETAG_COUNT" -eq 0 ]; then
+    echo -e "${YELLOW}No ETags found (download may have been too brief)${NC}"
+    rm -rf "$TEST_DIR"
+    exit 0
+fi
+
+# Check if every ETag range exists in the file
+echo -e "\n${YELLOW}Validating: Every cached ETag must have corresponding data in file...${NC}"
+MISSING_RANGES=""
+for range in $ETAG_RANGES; do
+    if ! echo "$FILE_RANGES" | grep -q "^${range}$"; then
+        MISSING_RANGES="$MISSING_RANGES $range"
+    fi
+done
+
+if [ -n "$MISSING_RANGES" ]; then
+    echo -e "${RED}✗ FAILURE: Found ETags for ranges not in file!${NC}"
+    echo -e "${RED}Missing ranges:$MISSING_RANGES${NC}"
+    echo -e "\n${YELLOW}This means on resume, these ranges would be skipped (data loss!)${NC}"
+
+    # Show first few for debugging
+    echo -e "\n${YELLOW}First 10 ETags:${NC}"
+    echo "$ETAG_RANGES" | head -10
+    echo -e "\n${YELLOW}First 10 file ranges:${NC}"
+    echo "$FILE_RANGES" | head -10
+
+    rm -rf "$TEST_DIR"
+    exit 1
+else
+    echo -e "${GREEN}✓ All cached ETags have corresponding data in file${NC}"
+fi
+
+# Check for extra ranges in file (shouldn't happen, but good to verify)
+EXTRA_RANGES=""
+for range in $FILE_RANGES; do
+    if ! echo "$ETAG_RANGES" | grep -q "^${range}$"; then
+        EXTRA_RANGES="$EXTRA_RANGES $range"
+    fi
+done
+
+if [ -n "$EXTRA_RANGES" ]; then
+    echo -e "${YELLOW}⚠ Warning: File contains ranges without ETags (count: $(echo $EXTRA_RANGES | wc -w | tr -d ' '))${NC}"
+    echo -e "${YELLOW}This could happen if writes succeeded but ETag updates failed${NC}"
+else
+    echo -e "${GREEN}✓ No extra ranges in file${NC}"
+fi
+
+# Verify ranges in file are consecutive from 00000
+echo -e "\n${YELLOW}Checking for gaps in sequence...${NC}"
+EXPECTED=0
+HAS_GAP=false
+for range in $FILE_RANGES; do
+    DECIMAL=$((16#$range))
+    if [ $DECIMAL -ne $EXPECTED ]; then
+        echo -e "${RED}✗ Gap detected! Expected $(printf "%05X" $EXPECTED), found $range${NC}"
+        HAS_GAP=true
+        break
+    fi
+    EXPECTED=$((EXPECTED + 1))
+done
+
+if [ "$HAS_GAP" = true ]; then
+    echo -e "${RED}✗ FAILURE: File has gaps in sequence${NC}"
+    rm -rf "$TEST_DIR"
+    exit 1
+else
+    echo -e "${GREEN}✓ File has no gaps (ranges 00000 to $(printf "%05X" $((EXPECTED - 1))))${NC}"
+fi
+
+# Test resume doesn't skip the ranges that ARE in the file
+echo -e "\n${GREEN}Testing resume doesn't re-download ranges that are already in file...${NC}"
+RANGES_BEFORE=$FILE_COUNT
+
+(./target/release/pwned-passwords-downloader-rs \
+    --combine \
+    --output-directory "$TEST_DIR" \
+    --max-concurrent-requests 32 \
+    --resume \
+    --quiet) &
+PID=$!
+sleep 5
+kill -INT $PID 2>/dev/null || true
+wait $PID 2>/dev/null || true
+
+FILE_RANGES_AFTER=$(grep "^# Range:" "$TEST_DIR/pwned-passwords-combined.txt" 2>/dev/null | awk '{print $3}' | sort || true)
+FILE_COUNT_AFTER=$(echo "$FILE_RANGES_AFTER" | grep -v '^$' | wc -l | tr -d ' ')
+
+echo "Ranges after resume: $FILE_COUNT_AFTER"
+echo "Ranges added: $((FILE_COUNT_AFTER - RANGES_BEFORE))"
+
+# Verify all original ranges still exist
+ALL_PRESENT=true
+for range in $FILE_RANGES; do
+    if ! echo "$FILE_RANGES_AFTER" | grep -q "^${range}$"; then
+        echo -e "${RED}✗ Range $range disappeared after resume!${NC}"
+        ALL_PRESENT=false
+    fi
+done
+
+if [ "$ALL_PRESENT" = true ]; then
+    echo -e "${GREEN}✓ All original ranges still present after resume${NC}"
+else
+    echo -e "${RED}✗ FAILURE: Data loss on resume${NC}"
+    rm -rf "$TEST_DIR"
+    exit 1
+fi
+
+# Final verification: still no gaps
+echo -e "\n${YELLOW}Final gap check...${NC}"
+EXPECTED=0
+HAS_GAP=false
+for range in $FILE_RANGES_AFTER; do
+    DECIMAL=$((16#$range))
+    if [ $DECIMAL -ne $EXPECTED ]; then
+        echo -e "${RED}✗ Gap after resume! Expected $(printf "%05X" $EXPECTED), found $range${NC}"
+        HAS_GAP=true
+        break
+    fi
+    EXPECTED=$((EXPECTED + 1))
+done
+
+if [ "$HAS_GAP" = true ]; then
+    echo -e "${RED}✗ FAILURE: Gaps appeared after resume${NC}"
+    rm -rf "$TEST_DIR"
+    exit 1
+else
+    echo -e "${GREEN}✓ No gaps after resume${NC}"
+fi
+
+echo -e "\n${GREEN}=== All ETag synchronization tests PASSED ===${NC}"
+
+# Cleanup
+rm -rf "$TEST_DIR"

--- a/src/args.rs
+++ b/src/args.rs
@@ -68,12 +68,16 @@ pub struct Args {
     pub max_concurrent_requests: usize,
 
     /// Number of retry attempts for failed requests
-    #[arg(long, default_value_t = 5, value_parser = parse_greater_than_zero)]
+    #[arg(long, default_value_t = 10, value_parser = parse_greater_than_zero)]
     pub max_retries: usize,
 
     /// Resume previous download session
     #[arg(long, num_args=0..=1, default_value_t = true)]
     pub resume: bool,
+
+    /// Sync with existing ETag cache file (only download changed ranges)
+    #[arg(long)]
+    pub sync: Option<PathBuf>,
 
     /// Directory for storing downloaded hashes
     #[arg(long, short, default_value = ".")]
@@ -82,6 +86,10 @@ pub struct Args {
     /// Disable progress bar output
     #[arg(long, short, default_value_t = false)]
     pub quiet: bool,
+
+    /// Download all ranges as a single file
+    #[arg(long, short, default_value_t = false)]
+    pub combine: bool,
 
     /// User-Agent string for HTTP requests
     #[arg(long, short, default_value_t = concat!("hibp-downloader/",

--- a/src/combined_writer.rs
+++ b/src/combined_writer.rs
@@ -1,0 +1,319 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::sync::Arc;
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+use tokio_util::bytes::Bytes;
+
+use crate::etag::ETagCache;
+use crate::hash_writer::HashWriter;
+
+const COMBINED_OUTPUT_FILENAME: &str = "pwned-passwords-combined.txt";
+const DEBUG_LOG_FILENAME: &str = "download_debug.log";
+
+/// Buffered range data: (hash_prefix, data, etag)
+type BufferedRange = (String, Bytes, Option<String>);
+
+/// Prepend the 5-character range prefix to each line in the data
+/// HIBP API returns hash suffixes (35 chars), we need full 40-char SHA-1 hashes
+fn prepend_prefix_to_lines(prefix: &str, data: &[u8]) -> Vec<u8> {
+    let data_str = String::from_utf8_lossy(data);
+    let mut result = Vec::new();
+
+    for line in data_str.lines() {
+        if !line.is_empty() {
+            result.extend_from_slice(prefix.as_bytes());
+            result.extend_from_slice(line.as_bytes());
+            result.push(b'\n');
+        }
+    }
+
+    // Remove trailing newline if original data didn't have one
+    if !data.ends_with(b"\n") && !result.is_empty() {
+        result.pop();
+    }
+
+    result
+}
+
+/// Manages ordered writing of ranges to a single combined file
+pub struct CombinedWriter {
+    file: Arc<Mutex<fs::File>>,
+    debug_log: Arc<Mutex<fs::File>>,
+    pending_buffer: Arc<Mutex<BTreeMap<u64, BufferedRange>>>,
+    next_sequence: Arc<Mutex<u64>>,
+    total_bytes: Arc<Mutex<u64>>,
+    total_ranges: Arc<Mutex<u64>>,
+    resume_cache: Arc<Mutex<ETagCache>>,
+}
+
+impl CombinedWriter {
+    pub async fn new(
+        output_dir: &Path,
+        resume: bool,
+        resume_cache: Arc<Mutex<ETagCache>>,
+    ) -> anyhow::Result<Self> {
+        let output_path = output_dir.join(COMBINED_OUTPUT_FILENAME);
+        let debug_log_path = output_dir.join(DEBUG_LOG_FILENAME);
+
+        // If resuming, append to existing file; otherwise truncate
+        let file = if resume && output_path.exists() {
+            tracing::info!("Resuming combined download, appending to existing file");
+            fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&output_path)
+                .await?
+        } else {
+            fs::OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(&output_path)
+                .await?
+        };
+
+        // Create debug log (append mode to preserve history across resumes)
+        let debug_log = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&debug_log_path)
+            .await?;
+
+        Ok(Self {
+            file: Arc::new(Mutex::new(file)),
+            debug_log: Arc::new(Mutex::new(debug_log)),
+            pending_buffer: Arc::new(Mutex::new(BTreeMap::new())),
+            next_sequence: Arc::new(Mutex::new(0)),
+            total_bytes: Arc::new(Mutex::new(0)),
+            total_ranges: Arc::new(Mutex::new(0)),
+            resume_cache,
+        })
+    }
+
+    /// Add a downloaded range to the buffer
+    /// Writes any consecutive ranges that are now ready
+    async fn add_range(
+        &self,
+        sequence: u64,
+        hash_prefix: String,
+        data: Bytes,
+        etag: Option<String>,
+    ) -> anyhow::Result<()> {
+        let mut pending = self.pending_buffer.lock().await;
+        pending.insert(sequence, (hash_prefix, data, etag));
+        drop(pending);
+
+        // Try to write any consecutive ranges (ETags are cached internally)
+        self.write_pending_ranges().await?;
+
+        Ok(())
+    }
+
+    /// Write all consecutive pending ranges to disk in order
+    /// Updates resume cache immediately for all written ranges
+    async fn write_pending_ranges(&self) -> anyhow::Result<()> {
+        loop {
+            // Check what ranges are ready to write (minimal lock scope)
+            let ranges_to_write = {
+                let next_seq = self.next_sequence.lock().await;
+                let mut pending = self.pending_buffer.lock().await;
+
+                let current_next = *next_seq;
+                let mut batch = Vec::new();
+                let mut seq = current_next;
+
+                // Collect up to 100 consecutive ranges
+                while batch.len() < 100 {
+                    if let Some(range) = pending.remove(&seq) {
+                        batch.push((seq, range));
+                        seq += 1;
+                    } else {
+                        break;
+                    }
+                }
+
+                batch
+            };
+
+            if ranges_to_write.is_empty() {
+                break;
+            }
+
+            // Write the batch (locks only what's needed, when needed)
+            let mut file = self.file.lock().await;
+            let mut debug_log = self.debug_log.lock().await;
+
+            for (seq, (hash_prefix, data, etag)) in ranges_to_write {
+                // HIBP API returns hash suffix (35 chars) without the 5-char prefix
+                // We need to prepend the range prefix to each line for full 40-char SHA-1 hashes
+                let data_with_prefix = prepend_prefix_to_lines(&hash_prefix, &data);
+
+                let needs_newline = !data_with_prefix.ends_with(b"\n");
+                let bytes_written = data_with_prefix.len() + if needs_newline { 1 } else { 0 };
+
+                // Try to write this range - if it fails, remove from cache and propagate error
+                let write_result = async {
+                    file.write_all(&data_with_prefix).await?;
+                    if needs_newline {
+                        file.write_all(b"\n").await?;
+                    }
+                    Ok::<(), std::io::Error>(())
+                }
+                .await;
+
+                match write_result {
+                    Ok(()) => {
+                        // Update counters
+                        {
+                            let mut total_bytes = self.total_bytes.lock().await;
+                            let mut total_ranges = self.total_ranges.lock().await;
+                            *total_bytes += bytes_written as u64;
+                            *total_ranges += 1;
+                        }
+
+                        // Update resume cache immediately when range is written to disk
+                        if let Some(etag_value) = &etag {
+                            let mut cache = self.resume_cache.lock().await;
+                            cache.etags.insert(hash_prefix.clone(), etag_value.clone());
+                        }
+
+                        // Write debug log entry
+                        let debug_entry = format!(
+                            "seq={:06X} range={} bytes={} etag={}\n",
+                            seq,
+                            hash_prefix,
+                            bytes_written,
+                            etag.as_deref().unwrap_or("none")
+                        );
+                        let _ = debug_log.write_all(debug_entry.as_bytes()).await;
+
+                        // Advance next sequence
+                        {
+                            let mut next_seq = self.next_sequence.lock().await;
+                            *next_seq = seq + 1;
+                        }
+                    }
+                    Err(e) => {
+                        drop(file); // Release file lock before other operations
+                        drop(debug_log);
+
+                        // Write failed - remove from cache to ensure retry
+                        let mut cache = self.resume_cache.lock().await;
+                        cache.etags.remove(&hash_prefix);
+                        return Err(anyhow::anyhow!("Failed to write range {hash_prefix}: {e}"));
+                    }
+                }
+            }
+
+            // Flush after batch
+            file.flush().await?;
+            debug_log.flush().await?;
+            drop(file); // Release lock before logging/checking
+            drop(debug_log);
+
+            // Log progress periodically
+            {
+                let total_ranges = *self.total_ranges.lock().await;
+                if total_ranges % 1000 == 0 {
+                    let next_seq = *self.next_sequence.lock().await;
+                    let total_bytes = *self.total_bytes.lock().await;
+                    let progress_pct = (next_seq as f64 / 0x100000 as f64) * 100.0;
+                    let size_gb = total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+
+                    tracing::info!(
+                        "Combined progress: {:05X}/{:05X} ({:.1}%) - {:.2} GB written",
+                        next_seq,
+                        0xFFFFF,
+                        progress_pct,
+                        size_gb
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl HashWriter for CombinedWriter {
+    async fn write_range(
+        &self,
+        sequence: u64,
+        hash_prefix: &str,
+        data: Bytes,
+        etag: Option<String>,
+    ) -> anyhow::Result<()> {
+        self.add_range(sequence, hash_prefix.to_string(), data, etag)
+            .await
+    }
+
+    async fn finalize(&self) -> anyhow::Result<()> {
+        // Write any remaining pending ranges
+        self.write_pending_ranges().await?;
+
+        let mut file = self.file.lock().await;
+        file.flush().await?;
+
+        let total_ranges = *self.total_ranges.lock().await;
+        let total_bytes = *self.total_bytes.lock().await;
+        let size_gb = total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+
+        tracing::info!(
+            "Combined download complete: {} ranges, {:.2} GB written",
+            total_ranges,
+            size_gb
+        );
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_prepend_prefix_to_lines() {
+        // Test basic case with multiple lines
+        let prefix = "00000";
+        let data =
+            b"0005AD76BD555C1D6D771DE417A4B87E4B4:10\n000A8DAE4228F821FB418F59826079BF368:4\n";
+        let result = prepend_prefix_to_lines(prefix, data);
+        let expected = b"000000005AD76BD555C1D6D771DE417A4B87E4B4:10\n00000000A8DAE4228F821FB418F59826079BF368:4\n";
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_prepend_prefix_no_trailing_newline() {
+        let prefix = "FFFFF";
+        // HIBP returns 35 characters (without the 5-char range prefix)
+        let data = b"FFEE791CBAC0F6305CAF0CEE06BBE131160:4";
+        let result = prepend_prefix_to_lines(prefix, data);
+        // Full hash should be 40 chars: 5 (prefix) + 35 (suffix) = 40
+        let expected = b"FFFFFFFEE791CBAC0F6305CAF0CEE06BBE131160:4";
+        assert_eq!(result, expected);
+        assert_eq!(result.iter().take_while(|&&b| b != b':').count(), 40); // Verify hash is 40 chars
+    }
+
+    #[test]
+    fn test_prepend_prefix_empty_lines_ignored() {
+        let prefix = "00001";
+        let data =
+            b"0005AD76BD555C1D6D771DE417A4B87E4B4:10\n\n000A8DAE4228F821FB418F59826079BF368:4\n";
+        let result = prepend_prefix_to_lines(prefix, data);
+        let expected = b"000010005AD76BD555C1D6D771DE417A4B87E4B4:10\n00001000A8DAE4228F821FB418F59826079BF368:4\n";
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_prepend_prefix_single_line() {
+        let prefix = "ABC12";
+        let data = b"34567890123456789012345678901234:999\n";
+        let result = prepend_prefix_to_lines(prefix, data);
+        let expected = b"ABC1234567890123456789012345678901234:999\n";
+        assert_eq!(result, expected);
+    }
+}

--- a/src/download.rs
+++ b/src/download.rs
@@ -18,19 +18,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use futures::{TryFutureExt as _, TryStreamExt as _};
 use reqwest::{StatusCode, header};
-use std::{error::Error as _, path::PathBuf, time::Duration};
+use std::{error::Error as _, time::Duration};
 use thiserror::Error;
-use tokio::{fs, io::AsyncWriteExt as _, time::sleep};
-use tokio_util::io::StreamReader;
+use tokio::time::sleep;
+use tokio_util::bytes::Bytes;
 
 use crate::args::Args;
 
-const HIBP_BASE_URL: &str = "https://api.pwnedpasswords.com/range/";
-
 #[derive(Error, Debug)]
 pub enum DownloadError {
+    #[allow(dead_code)]
     #[error("{operation} operation on {path} failed: {source}")]
     FileOperation {
         operation: &'static str,
@@ -57,9 +55,21 @@ pub enum DownloadError {
     },
 }
 
+/// Result of a successful download operation
+#[derive(Debug)]
+pub enum DownloadResult {
+    /// Successfully downloaded new data with optional ETag
+    Success { etag: Option<String>, data: Bytes },
+    /// Resource not modified (304 response)
+    NotModified,
+}
+
+/// Internal error classification for retry logic
 #[derive(Debug)]
 enum InternalDownloadError {
+    /// Fatal error that should not be retried
     Fatal(DownloadError),
+    /// Retriable error that may succeed on retry
     Retriable(DownloadError),
 }
 
@@ -71,141 +81,92 @@ impl From<InternalDownloadError> for DownloadError {
     }
 }
 
-async fn write_hash_to_file(
-    response: reqwest::Response,
-    final_path: &PathBuf,
-) -> Result<(), InternalDownloadError> {
-    let part_path = final_path.with_extension("part");
+/// Returns InternalDownloadError to distinguish fatal vs retriable errors
+async fn download_hash_once(
+    hash: &str,
+    client: &reqwest::Client,
+    etag: Option<&str>,
+    args: &Args,
+    base_url: &str,
+) -> Result<DownloadResult, InternalDownloadError> {
+    let mut request = client.get(format!("{base_url}{hash}"));
 
-    let mut file = fs::File::create(&part_path).await.map_err(|source| {
-        InternalDownloadError::Fatal(DownloadError::FileOperation {
-            operation: "create",
-            path: part_path.display().to_string(),
-            source,
-        })
-    })?;
+    // Add If-None-Match header if we have an etag and (resuming OR syncing)
+    if (args.resume || args.sync.is_some())
+        && let Some(etag_value) = etag
+    {
+        request = request.header(header::IF_NONE_MATCH, etag_value);
+    }
 
-    let stream = response.bytes_stream().map_err(std::io::Error::other);
-    let mut reader = StreamReader::new(stream);
+    match request.send().await {
+        Ok(response) => {
+            let status_code = response.status();
+            match status_code {
+                StatusCode::OK => {
+                    let new_etag = response
+                        .headers()
+                        .get(header::ETAG)
+                        .and_then(|s| s.to_str().ok())
+                        .map(String::from);
 
-    match tokio::io::copy(&mut reader, &mut file).await {
-        Ok(_) => {
-            file.flush()
-                .and_then(|_| fs::rename(&part_path, &final_path))
-                .or_else(|source| async {
-                    _ = fs::remove_file(&part_path).await;
-                    Err(InternalDownloadError::Fatal(DownloadError::FileOperation {
-                        operation: "rename",
-                        path: part_path.display().to_string(),
-                        source,
+                    // Download the entire response body
+                    match response.bytes().await {
+                        Ok(data) => Ok(DownloadResult::Success {
+                            etag: new_etag,
+                            data,
+                        }),
+                        Err(err) => Err(InternalDownloadError::Retriable(DownloadError::Network {
+                            hash: hash.to_string(),
+                            error: err.to_string(),
+                            retries: 0,
+                        })),
+                    }
+                }
+                StatusCode::NOT_MODIFIED if args.resume || args.sync.is_some() => {
+                    Ok(DownloadResult::NotModified)
+                }
+                status_code if status_code.is_client_error() => {
+                    Err(InternalDownloadError::Fatal(DownloadError::Client {
+                        hash: hash.to_string(),
+                        status_code,
                     }))
-                })
-                .await?;
-            Ok(())
+                }
+                status_code => Err(InternalDownloadError::Retriable(DownloadError::Http {
+                    hash: hash.to_string(),
+                    status_code,
+                    retries: 0,
+                })),
+            }
         }
-        Err(err) => {
-            _ = fs::remove_file(&part_path).await;
-            Err(InternalDownloadError::Retriable(
-                DownloadError::FileOperation {
-                    operation: "read/write",
-                    path: final_path.display().to_string(),
-                    source: err,
-                },
-            ))
-        }
+        Err(err) => Err(InternalDownloadError::Retriable(DownloadError::Network {
+            hash: hash.to_string(),
+            error: err
+                .source()
+                .map(|e| e.to_string())
+                .unwrap_or_else(|| err.to_string()),
+            retries: 0,
+        })),
     }
 }
 
 pub async fn download_hash(
     hash: &str,
-    client: reqwest::Client,
-    etag: Option<&str>,
-    args: &Args,
-) -> Result<Option<String>, DownloadError> {
-    download_hash_with_url(hash, client, etag, args, HIBP_BASE_URL).await
-}
-
-async fn download_hash_with_url(
-    hash: &str,
-    client: reqwest::Client,
+    client: &reqwest::Client,
     etag: Option<&str>,
     args: &Args,
     base_url: &str,
-) -> Result<Option<String>, DownloadError> {
-    let ext = args.compression.as_str();
-    let final_path = args.output_directory.join(hash).with_extension(ext);
-
-    for retry in 0..args.max_retries {
-        let mut request = client.get(format!("{base_url}{hash}"));
-
-        if args.resume
-            && final_path.exists()
-            && let Some(etag_value) = etag
-        {
-            request = request.header(header::IF_NONE_MATCH, etag_value);
-        }
-
-        match request.send().await {
-            Ok(response) => {
-                let status_code = response.status();
-                match status_code {
-                    StatusCode::OK => {
-                        let etag = response
-                            .headers()
-                            .get(header::ETAG)
-                            .and_then(|s| s.to_str().ok())
-                            .map(String::from);
-
-                        match write_hash_to_file(response, &final_path).await {
-                            Ok(_) => {
-                                return Ok(etag);
-                            }
-                            Err(InternalDownloadError::Fatal(err)) => {
-                                return Err(err);
-                            }
-                            Err(InternalDownloadError::Retriable(err)) => {
-                                if retry == args.max_retries - 1 {
-                                    return Err(err);
-                                }
-                            }
-                        }
-                    }
-                    StatusCode::NOT_MODIFIED if args.resume => {
-                        return Ok(None);
-                    }
-                    status_code if status_code.is_client_error() => {
-                        return Err(DownloadError::Client {
-                            hash: hash.to_string(),
-                            status_code,
-                        });
-                    }
-                    status_code => {
-                        if retry == args.max_retries - 1 {
-                            return Err(DownloadError::Http {
-                                hash: hash.to_string(),
-                                status_code,
-                                retries: args.max_retries,
-                            });
-                        }
-                    }
+) -> Result<DownloadResult, DownloadError> {
+    for retry in 1..=args.max_retries {
+        match download_hash_once(hash, client, etag, args, base_url).await {
+            Ok(result) => return Ok(result),
+            Err(InternalDownloadError::Fatal(err)) => return Err(err),
+            Err(InternalDownloadError::Retriable(err)) => {
+                if retry == args.max_retries {
+                    return Err(err);
                 }
+                // Exponential backoff before retry
+                sleep(Duration::from_secs(u64::pow(2, (retry - 1) as u32))).await;
             }
-            Err(err) => {
-                if retry == args.max_retries - 1 {
-                    return Err(DownloadError::Network {
-                        hash: hash.to_string(),
-                        error: err
-                            .source()
-                            .map(|e| e.to_string())
-                            .unwrap_or_else(|| err.to_string()),
-                        retries: args.max_retries,
-                    });
-                }
-            }
-        }
-
-        if retry < args.max_retries - 1 {
-            sleep(Duration::from_secs(u64::pow(2, retry as u32))).await;
         }
     }
 
@@ -219,7 +180,6 @@ mod tests {
     use mockito::Server;
     use std::path::PathBuf;
     use tempfile::TempDir;
-    use tokio::fs;
 
     fn create_test_args(output_dir: PathBuf) -> Args {
         Args {
@@ -227,8 +187,10 @@ mod tests {
             max_concurrent_requests: 1,
             max_retries: 3,
             resume: false,
+            sync: None,
             output_directory: output_dir,
             quiet: true,
+            combine: false,
             user_agent: "test-agent/1.0".to_string(),
         }
     }
@@ -249,29 +211,54 @@ mod tests {
             .await;
 
         let client = reqwest::Client::builder().build().unwrap();
-
         let base_url = server.url();
 
-        let result = download_hash_with_url(
-            "AAAAA",
-            client,
-            None,
-            &args,
-            &format!("{}/range/", base_url),
-        )
-        .await;
+        let result =
+            download_hash("AAAAA", &client, None, &args, &format!("{base_url}/range/")).await;
 
         mock.assert_async().await;
 
         assert!(result.is_ok());
-        let etag = result.unwrap();
-        assert_eq!(etag, Some("\"test-etag\"".to_string()));
+        match result.unwrap() {
+            DownloadResult::Success { etag, data } => {
+                assert_eq!(etag, Some("\"test-etag\"".to_string()));
+                assert_eq!(data, mock_data.as_bytes());
+            }
+            _ => panic!("Expected Success result"),
+        }
+    }
 
-        let file_path = temp_dir.path().join("AAAAA");
-        assert!(file_path.exists());
+    #[tokio::test]
+    async fn test_download_hash_with_data() {
+        let mut server = Server::new_async().await;
+        let temp_dir = TempDir::new().unwrap();
+        let args = create_test_args(temp_dir.path().to_path_buf());
 
-        let content = fs::read_to_string(&file_path).await.unwrap();
-        assert_eq!(content, mock_data);
+        let mock_data = "000000000000000000000000000000000AA:1\r\n";
+        let mock = server
+            .mock("GET", "/range/00000")
+            .with_status(200)
+            .with_header("etag", "\"test-etag-2\"")
+            .with_body(mock_data)
+            .create_async()
+            .await;
+
+        let client = reqwest::Client::builder().build().unwrap();
+        let base_url = server.url();
+
+        let result =
+            download_hash("00000", &client, None, &args, &format!("{base_url}/range/")).await;
+
+        mock.assert_async().await;
+
+        assert!(result.is_ok());
+        match result.unwrap() {
+            DownloadResult::Success { etag, data } => {
+                assert_eq!(etag, Some("\"test-etag-2\"".to_string()));
+                assert_eq!(data, mock_data.as_bytes());
+            }
+            _ => panic!("Expected Success result"),
+        }
     }
 
     #[tokio::test]
@@ -280,9 +267,6 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let mut args = create_test_args(temp_dir.path().to_path_buf());
         args.resume = true;
-
-        let file_path = temp_dir.path().join("BBBBB");
-        fs::write(&file_path, "existing content").await.unwrap();
 
         let mock = server
             .mock("GET", "/range/BBBBB")
@@ -294,20 +278,19 @@ mod tests {
         let client = reqwest::Client::new();
         let base_url = server.url();
 
-        let result = download_hash_with_url(
+        let result = download_hash(
             "BBBBB",
-            client,
+            &client,
             Some("\"existing-etag\""),
             &args,
-            &format!("{}/range/", base_url),
+            &format!("{base_url}/range/"),
         )
         .await;
 
         mock.assert_async().await;
 
         assert!(result.is_ok());
-        let etag = result.unwrap();
-        assert_eq!(etag, None);
+        assert!(matches!(result.unwrap(), DownloadResult::NotModified));
     }
 
     #[tokio::test]
@@ -325,14 +308,8 @@ mod tests {
         let client = reqwest::Client::new();
         let base_url = server.url();
 
-        let result = download_hash_with_url(
-            "CCCCC",
-            client,
-            None,
-            &args,
-            &format!("{}/range/", base_url),
-        )
-        .await;
+        let result =
+            download_hash("CCCCC", &client, None, &args, &format!("{base_url}/range/")).await;
 
         mock.assert_async().await;
 
@@ -363,14 +340,8 @@ mod tests {
         let client = reqwest::Client::new();
         let base_url = server.url();
 
-        let result = download_hash_with_url(
-            "DDDDD",
-            client,
-            None,
-            &args,
-            &format!("{}/range/", base_url),
-        )
-        .await;
+        let result =
+            download_hash("DDDDD", &client, None, &args, &format!("{base_url}/range/")).await;
 
         mock.assert_async().await;
 
@@ -391,63 +362,102 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_download_hash_with_compression() {
+    async fn test_download_hash_network_error() {
+        let temp_dir = TempDir::new().unwrap();
+        let args = create_test_args(temp_dir.path().to_path_buf());
+
+        // Use an invalid URL that will cause a network error
+        let client = reqwest::Client::new();
+
+        // Override with a test helper that uses an invalid base URL
+        let result = download_hash(
+            "FFFFF",
+            &client,
+            None,
+            &args,
+            "http://invalid-domain-that-does-not-exist-12345.com/",
+        )
+        .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err, DownloadError::Network { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_download_hash_sync_not_modified() {
         let mut server = Server::new_async().await;
         let temp_dir = TempDir::new().unwrap();
         let mut args = create_test_args(temp_dir.path().to_path_buf());
-        args.compression = CompressionFormat::Gzip;
 
-        let mock_data = "test compressed data";
+        // Enable sync mode with a path (content doesn't matter for this test)
+        args.sync = Some(temp_dir.path().join("sync_cache.json"));
+
         let mock = server
-            .mock("GET", "/range/EEEEE")
-            .with_status(200)
-            .with_header("etag", "\"gzip-etag\"")
-            .with_body(mock_data)
+            .mock("GET", "/range/SSSSS")
+            .match_header("if-none-match", "\"sync-etag\"")
+            .with_status(304)
             .create_async()
             .await;
 
         let client = reqwest::Client::new();
         let base_url = server.url();
 
-        let result = download_hash_with_url(
-            "EEEEE",
-            client,
-            None,
+        let result = download_hash(
+            "SSSSS",
+            &client,
+            Some("\"sync-etag\""),
             &args,
-            &format!("{}/range/", base_url),
+            &format!("{base_url}/range/"),
         )
         .await;
 
         mock.assert_async().await;
 
         assert!(result.is_ok());
-
-        let file_path = temp_dir.path().join("EEEEE.gz");
-        assert!(file_path.exists());
-
-        let content = fs::read_to_string(&file_path).await.unwrap();
-        assert_eq!(content, mock_data);
+        assert!(matches!(result.unwrap(), DownloadResult::NotModified));
     }
 
     #[tokio::test]
-    async fn test_write_hash_to_file_success() {
+    async fn test_download_hash_sync_modified() {
+        let mut server = Server::new_async().await;
         let temp_dir = TempDir::new().unwrap();
-        let final_path = temp_dir.path().join("FFFFF");
+        let mut args = create_test_args(temp_dir.path().to_path_buf());
 
-        let mock_body = "test content";
-        let response = reqwest::Response::from(
-            http::Response::builder()
-                .status(200)
-                .body(mock_body)
-                .unwrap(),
-        );
+        // Enable sync mode
+        args.sync = Some(temp_dir.path().join("sync_cache.json"));
 
-        let result = write_hash_to_file(response, &final_path).await;
+        let new_data = "updated data";
+        let mock = server
+            .mock("GET", "/range/TTTTT")
+            .match_header("if-none-match", "\"old-etag\"")
+            .with_status(200)
+            .with_header("etag", "\"new-etag\"")
+            .with_body(new_data)
+            .create_async()
+            .await;
+
+        let client = reqwest::Client::new();
+        let base_url = server.url();
+
+        let result = download_hash(
+            "TTTTT",
+            &client,
+            Some("\"old-etag\""),
+            &args,
+            &format!("{base_url}/range/"),
+        )
+        .await;
+
+        mock.assert_async().await;
 
         assert!(result.is_ok());
-        assert!(final_path.exists());
-
-        let content = fs::read_to_string(&final_path).await.unwrap();
-        assert_eq!(content, mock_body);
+        match result.unwrap() {
+            DownloadResult::Success { etag, data } => {
+                assert_eq!(etag, Some("\"new-etag\"".to_string()));
+                assert_eq!(data, new_data.as_bytes());
+            }
+            _ => panic!("Expected Success result"),
+        }
     }
 }

--- a/src/hash_writer.rs
+++ b/src/hash_writer.rs
@@ -1,0 +1,30 @@
+use tokio_util::bytes::Bytes;
+
+/// Trait for writing downloaded hash range data to storage.
+/// Allows different strategies for organizing downloaded data (individual files vs combined file).
+#[async_trait::async_trait]
+pub trait HashWriter: Send + Sync {
+    /// Write a downloaded hash range to storage.
+    ///
+    /// Implementations are responsible for updating the resume cache when data is written to disk.
+    ///
+    /// # Arguments
+    /// * `sequence` - The numeric sequence (0..=0xFFFFF) for ordering
+    /// * `hash_prefix` - The 5-character hex prefix (e.g., "00000")
+    /// * `data` - The downloaded hash data
+    /// * `etag` - Optional ETag for resume/sync functionality
+    ///
+    /// # Returns
+    /// * `Ok(())` - Data was successfully written or buffered
+    /// * `Err(_)` - Write operation failed
+    async fn write_range(
+        &self,
+        sequence: u64,
+        hash_prefix: &str,
+        data: Bytes,
+        etag: Option<String>,
+    ) -> anyhow::Result<()>;
+
+    /// Finalize any pending writes and flush buffers.
+    async fn finalize(&self) -> anyhow::Result<()>;
+}

--- a/src/individual_writer.rs
+++ b/src/individual_writer.rs
@@ -1,0 +1,126 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+use tokio_util::bytes::Bytes;
+
+use crate::args::Args;
+use crate::etag::ETagCache;
+use crate::hash_writer::HashWriter;
+
+const DEBUG_LOG_FILENAME: &str = "download_debug.log";
+
+/// Writer that saves each hash range to a separate file.
+pub struct IndividualFileWriter {
+    args: Args,
+    resume_cache: Arc<Mutex<ETagCache>>,
+    debug_log: Arc<Mutex<fs::File>>,
+}
+
+impl IndividualFileWriter {
+    pub async fn new(args: Args, resume_cache: Arc<Mutex<ETagCache>>) -> anyhow::Result<Self> {
+        let debug_log_path = args.output_directory.join(DEBUG_LOG_FILENAME);
+
+        // Create debug log (append mode to preserve history across resumes)
+        let debug_log = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&debug_log_path)
+            .await?;
+
+        Ok(Self {
+            args,
+            resume_cache,
+            debug_log: Arc::new(Mutex::new(debug_log)),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl HashWriter for IndividualFileWriter {
+    async fn write_range(
+        &self,
+        sequence: u64,
+        hash_prefix: &str,
+        data: Bytes,
+        etag: Option<String>,
+    ) -> anyhow::Result<()> {
+        let ext = self.args.compression.as_str();
+        let final_path = self
+            .args
+            .output_directory
+            .join(hash_prefix)
+            .with_extension(ext);
+
+        let bytes_written = data.len();
+
+        match write_data_to_file(data, &final_path).await {
+            Ok(()) => {
+                // Update resume cache immediately after successful write
+                if let Some(etag_value) = &etag {
+                    let mut cache = self.resume_cache.lock().await;
+                    cache
+                        .etags
+                        .insert(hash_prefix.to_string(), etag_value.clone());
+                }
+
+                // Write debug log entry
+                let mut debug_log = self.debug_log.lock().await;
+                let debug_entry = format!(
+                    "seq={:06X} range={} bytes={} etag={} file={}\n",
+                    sequence,
+                    hash_prefix,
+                    bytes_written,
+                    etag.as_deref().unwrap_or("none"),
+                    final_path.display()
+                );
+                let _ = debug_log.write_all(debug_entry.as_bytes()).await;
+                let _ = debug_log.flush().await;
+
+                Ok(())
+            }
+            Err(e) => {
+                // Remove from cache on write error to ensure retry on next run
+                let mut cache = self.resume_cache.lock().await;
+                cache.etags.remove(hash_prefix);
+                Err(anyhow::anyhow!("Failed to write file: {e:?}"))
+            }
+        }
+    }
+
+    async fn finalize(&self) -> anyhow::Result<()> {
+        // No finalization needed for individual files
+        Ok(())
+    }
+}
+
+/// Write bytes data to a file using the part file pattern
+pub async fn write_data_to_file(data: Bytes, final_path: &PathBuf) -> anyhow::Result<()> {
+    let part_path = final_path.with_extension("part");
+
+    let mut file = fs::File::create(&part_path)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to create file {}: {}", part_path.display(), e))?;
+
+    file.write_all(&data)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to write to file {}: {}", part_path.display(), e))?;
+
+    file.flush()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to flush file {}: {}", part_path.display(), e))?;
+
+    if let Err(e) = fs::rename(&part_path, final_path).await {
+        // Clean up the part file on rename failure
+        let _ = fs::remove_file(&part_path).await;
+        return Err(anyhow::anyhow!(
+            "Failed to rename {} to {}: {}",
+            part_path.display(),
+            final_path.display(),
+            e
+        ));
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,10 +19,12 @@
 // SOFTWARE.
 
 mod args;
+mod combined_writer;
 mod download;
 mod etag;
+mod hash_writer;
+mod individual_writer;
 
-use futures::StreamExt as _;
 use indicatif::ProgressStyle;
 use std::sync::Arc;
 use tokio::{fs, sync::Mutex};
@@ -33,13 +35,21 @@ use tracing_subscriber::{
     fmt::writer::MakeWriterExt as _, layer::SubscriberExt as _, util::SubscriberInitExt as _,
 };
 
+use crate::args::Args;
+use crate::download::{DownloadResult, download_hash};
+use crate::etag::ETagCache;
+use crate::hash_writer::HashWriter;
+use futures::StreamExt;
+
 use args::parse_args;
-use download::download_hash;
-use etag::ETagCache;
+use combined_writer::CombinedWriter;
+use individual_writer::IndividualFileWriter;
 
 const ETAG_CACHE_FILENAME: &str = ".etag_cache.json";
 // Maximum hash value for HIBP API. This covers all possible SHA-1 hash prefixes (5 hex digits).
 const HASH_MAX: u64 = 0xFFFFF;
+
+pub const HIBP_BASE_URL: &str = "https://api.pwnedpasswords.com/range/";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -70,9 +80,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create output directory.
     fs::create_dir_all(&args.output_directory).await?;
 
-    // Load ETag cache
-    let etag_cache_path = args.output_directory.join(ETAG_CACHE_FILENAME);
-    let etag_cache = Arc::new(Mutex::new(ETagCache::load(&etag_cache_path).await?));
+    // Load resume cache (for current download session with --resume)
+    let resume_cache_path = args.output_directory.join(ETAG_CACHE_FILENAME);
+    let resume_cache = Arc::new(Mutex::new(ETagCache::load(&resume_cache_path).await?));
+
+    // Load sync cache if --sync is provided (represents previous state)
+    let sync_cache = if let Some(sync_path) = &args.sync {
+        Some(Arc::new(Mutex::new(ETagCache::load(sync_path).await?)))
+    } else {
+        None
+    };
 
     // Handle ctrl-c
     let token = CancellationToken::new();
@@ -88,54 +105,152 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         span.pb_start();
     }
 
-    futures::stream::iter(0..=HASH_MAX)
-        .take_until(token.cancelled())
-        .map(|hash| {
-            let client = client.clone();
-            let etag_cache = etag_cache.clone();
-            let hash = format!("{:05X}", hash);
-            let args = args.clone();
+    // Choose writer strategy based on --combine flag
+    let writer: Arc<dyn hash_writer::HashWriter> = if args.combine {
+        Arc::new(
+            CombinedWriter::new(&args.output_directory, args.resume, resume_cache.clone()).await?,
+        )
+    } else {
+        Arc::new(IndividualFileWriter::new(args.clone(), resume_cache.clone()).await?)
+    };
 
-            let result = async move {
-                let etag = if args.resume {
-                    etag_cache.lock().await.etags.get(&hash).cloned()
-                } else {
-                    None
-                };
-                let result = download_hash(&hash, client, etag.as_deref(), &args).await;
-                (hash, result)
-            };
-            span.pb_inc(1);
-            result
-        })
-        .buffer_unordered(args.max_concurrent_requests)
-        .for_each(|(hash, result)| {
-            let etag_cache = etag_cache.clone();
-            async move {
-                match result {
-                    Err(err) => {
-                        tracing::error!("{err}");
-                        // Remove etag on error to force re-download next time
-                        let mut cache = etag_cache.lock().await;
-                        cache.etags.remove(&hash);
-                    }
-                    Ok(Some(etag)) => {
-                        let mut cache = etag_cache.lock().await;
-                        cache.etags.insert(hash, etag);
-                    }
-                    Ok(None) => {
-                        // File was not modified (304 response)
-                    }
-                }
-            }
-        })
-        .await;
+    // Download all hashes using the unified function
+    download_all_hashes(
+        writer,
+        args.clone(),
+        client,
+        resume_cache.clone(),
+        sync_cache,
+        token,
+        span,
+        HASH_MAX,
+    )
+    .await?;
 
-    // Save ETag cache
-    let final_cache = etag_cache.lock().await;
+    // Save resume cache
+    let final_cache = resume_cache.lock().await;
     if let Err(err) = final_cache.save().await {
         tracing::error!("{err}");
     }
+
+    Ok(())
+}
+
+/// Download all hash ranges using the provided writer strategy.
+///
+/// This function handles:
+/// - Resume cache lookups for resume functionality
+/// - Sync cache lookups to skip unchanged ranges
+/// - Concurrent downloads with configurable concurrency
+/// - Progress bar updates
+/// - Cache updates on success/error
+/// - Cancellation support
+///
+/// # Arguments
+/// * `writer` - The writer strategy (individual files or combined file)
+/// * `args` - CLI arguments and configuration
+/// * `client` - HTTP client for downloading
+/// * `resume_cache` - Resume cache for --resume support (current download session)
+/// * `sync_cache` - Optional sync cache for --sync support (previous state for comparison)
+/// * `token` - Cancellation token for Ctrl-C handling
+/// * `span` - Tracing span for progress bar
+/// * `hash_max` - Maximum hash value (0xFFFFF for SHA-1)
+pub async fn download_all_hashes<W: HashWriter + ?Sized + 'static>(
+    writer: Arc<W>,
+    args: Args,
+    client: reqwest::Client,
+    resume_cache: Arc<Mutex<ETagCache>>,
+    sync_cache: Option<Arc<Mutex<ETagCache>>>,
+    token: CancellationToken,
+    span: tracing::Span,
+    hash_max: u64,
+) -> anyhow::Result<()> {
+    // Process all hash ranges
+    let results: Vec<Result<(), anyhow::Error>> = futures::stream::iter(0..=hash_max)
+        .take_until(token.cancelled())
+        .map(|sequence| {
+            let client = client.clone();
+            let writer = writer.clone();
+            let resume_cache = resume_cache.clone();
+            let sync_cache = sync_cache.clone();
+            let args = args.clone();
+            let span = span.clone();
+
+            async move {
+                let hash_prefix = format!("{sequence:05X}");
+
+                // Determine which ETag to use for the If-None-Match header
+                // Priority: resume cache (current session) > sync cache (previous state)
+                let resume_etag = if args.resume {
+                    let cache = resume_cache.lock().await;
+                    cache.etags.get(&hash_prefix).cloned()
+                } else {
+                    None
+                };
+                let sync_etag = if let Some(ref sync_cache) = sync_cache {
+                    let cache = sync_cache.lock().await;
+                    cache.etags.get(&hash_prefix).cloned()
+                } else {
+                    None
+                };
+
+                let existing_etag = if resume_etag.is_some() {
+                    resume_etag
+                } else {
+                    sync_etag
+                };
+
+                // Download the range
+                let result = match download_hash(
+                    &hash_prefix,
+                    &client,
+                    existing_etag.as_deref(),
+                    &args,
+                    HIBP_BASE_URL,
+                )
+                .await
+                {
+                    Ok(DownloadResult::Success { etag, data }) => {
+                        // New data received, write using the writer strategy
+                        // Writer handles ETag cache updates and error cleanup internally
+                        writer.write_range(sequence, &hash_prefix, data, etag).await
+                    }
+                    Ok(DownloadResult::NotModified) => {
+                        // 304 Not Modified - file hasn't changed, nothing to do
+                        tracing::debug!("Hash range {} was not modified", hash_prefix);
+                        Ok(())
+                    }
+                    Err(e) => Err(anyhow::anyhow!(
+                        "Failed to download range {hash_prefix}: {e}"
+                    )),
+                };
+
+                span.pb_inc(1);
+                result
+            }
+        })
+        .buffer_unordered(args.max_concurrent_requests)
+        .collect::<Vec<_>>()
+        .await;
+
+    // Check for any failures
+    let failures: Vec<_> = results.iter().filter_map(|r| r.as_ref().err()).collect();
+    if !failures.is_empty() {
+        tracing::error!("Download completed with {} failures", failures.len());
+        for (idx, err) in failures.iter().take(10).enumerate() {
+            tracing::error!("  Failure {}: {}", idx + 1, err);
+        }
+        if failures.len() > 10 {
+            tracing::error!("  ... and {} more failures", failures.len() - 10);
+        }
+        return Err(anyhow::anyhow!(
+            "Download incomplete: {} ranges failed",
+            failures.len()
+        ));
+    }
+
+    // Finalize the writer (flushes any remaining buffered data)
+    writer.finalize().await?;
 
     Ok(())
 }


### PR DESCRIPTION
Hi! Thanks for this tool, was really useful. To better support my expected workflows, I added a way to download the HIBP database as a single, sorted file (`--combine`) and a way to only download the "diff" of what I had already downloaded using eTags (`--sync`).

### `--combine`

To implement this, I made a `HashWriter` trait, and then had `IndividualWriter` / `CombinedWriter` as the implementations. When downloading the hashes the downloader function gets passed the respective writer.

Since I wanted to have the output file sorted, and the hash ranges are downloaded in parallel I had the `CombinedWriter` store a buffer of etags so it can write sequentially to the file as the "next range block" becomes available.

The combined writer prepends the hash prefix for each file (so it now stores the full 40-character sha1) because you can't infer the 5 digit k-anon prefix from the filename in this model.

Downloading using this took about ~10 minutes for me for the entire 56gb database, which seemed about on par with other downloaders.

### `--sync`

I wanted a way to only grab the changes to the HIBP since the last time I had downloaded the data. I felt the easiest way to get something similar was to use the eTags in a similar manner to how `--resume` worked. The `--sync` command accepts an etag cache, which I use as a smaller representation of the downloaded database.

If `--sync` is passed, I look up if the etag is the same in the etag cache and skip the range if needed similar to resume.

You can use `--sync` along with `--resume`, and it'll still respect both.

Using the sync cache now "downloads" the entire database in a couple (i.e. 2) minutes, as opposed to the 10-20 if doing the full download.

`test_etag_sync.sh` is a script I used to verify that the etag cache accurately matches what the actual downloaded state is if the process is killed. So, there's no extra etags in the cache for data that wasn't downloaded, or data that was downloaded was missing entries in the sync cache.